### PR TITLE
Update git clone URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for your interest in contributing to SDEverse! This document provides 
 
     ```bash
     # Clone your forked repository
-    git clone https://github.com/YOUR-USERNAME/SDEverse.git
+    git clone https://github.com/Harshdev625/SDEverse.git
 
     # Navigate into the project directory
     cd SDEverse


### PR DESCRIPTION
previously it was asking for username while cloning the repo locally because the link contains "YOUR_USERNAME" instead it should consist of the repo owner name which is "Harshdev625"

I have fixed the clone URL now!